### PR TITLE
Allow redis connection to be customized; Use seperate redis connection for each poll

### DIFF
--- a/lib/ost.rb
+++ b/lib/ost.rb
@@ -9,12 +9,17 @@ module Ost
     attr :backup
 
     def initialize(name)
-      @key = Nest.new(:ost)[name]
+      @name = name
+      @key = nest
       @backup = @key[Socket.gethostname][Process.pid]
     end
 
     def push(value)
       key.lpush(value)
+    end
+
+    def nest
+      Nest.new(:ost, redis)[@name]
     end
 
     def each(&block)
@@ -23,7 +28,7 @@ module Ost
       loop do
         break if @stopping
 
-        item = @key.brpoplpush(@backup, TIMEOUT)
+        item = nest.brpoplpush(@backup, TIMEOUT)
 
         next unless item
 
@@ -45,7 +50,7 @@ module Ost
     alias pop each
 
     def redis
-      @redis ||= Redis.connect(Ost.options)
+      Redis.connect(Ost.options)
     end
   end
 


### PR DESCRIPTION
Currently the redis connection that is created at initialize is not using the Ost.options that is setup by Ost.connect, which means if your redis is not in localhost and not using default port Ost won't work.

Also, performance is really slow if you attempt to producer and consume messages in the same process since it's all sharing the same redis connection. So I changed that for each call to each it creates a new redis connection. I don't think this is a problem since this each call is suppose to long polling anyway.
