### PR TITLE
Return query size

### DIFF
--- a/lib/ost.rb
+++ b/lib/ost.rb
@@ -43,6 +43,10 @@ module Ost
     alias << push
     alias pop each
 
+    def size
+      key.llen
+    end
+
     def redis
       @redis ||= Redis.connect(Ost.options)
     end

--- a/test/ost_test.rb
+++ b/test/ost_test.rb
@@ -135,4 +135,26 @@ scope do
 
     assert_equal queue.key.redis, queue.redis
   end
+
+  test "report the queue size" do
+    queue = Ost[:size]
+
+    assert_equal 0, queue.size
+
+    queue << 1
+
+    assert_equal 1, queue.size
+
+    done = false
+
+    Thread.new do
+      Ost[:size].each do |item|
+        done = true
+      end
+    end
+
+    until done; end
+
+    assert_equal 0, queue.size
+  end
 end


### PR DESCRIPTION
This is an utility method. It isn't hard to realize that `query.key.llen` will return the current size of the queue, but this makes it even easier.
