### PR TITLE
Fix bug with non-integer timeouts

### DIFF
--- a/lib/ost.rb
+++ b/lib/ost.rb
@@ -1,7 +1,7 @@
 require "nest"
 
 module Ost
-  TIMEOUT = ENV["OST_TIMEOUT"].to_i || 2
+  TIMEOUT = (ENV["OST_TIMEOUT"] || 2).to_i
 
   class Queue
     attr :key


### PR DESCRIPTION
I didn't have to add tests for this as they were already failing.
Gracias!
